### PR TITLE
Fix gradient name typo

### DIFF
--- a/shared/feature/src/commonMain/kotlin/com/moviearchive/feature/presentation/home/items/CelebrityItem.kt
+++ b/shared/feature/src/commonMain/kotlin/com/moviearchive/feature/presentation/home/items/CelebrityItem.kt
@@ -32,7 +32,7 @@ import com.moviearchive.ui.theme.NormalPadding
 import com.moviearchive.ui.theme.SmallEvelation
 import com.moviearchive.ui.theme.SmallPadding
 import com.moviearchive.ui.widget.AsyncImagePainter
-import com.moviearchive.ui.widget.VerticalGradiant
+import com.moviearchive.ui.widget.VerticalGradient
 
 @Composable
 fun CelebrityItem(
@@ -65,7 +65,7 @@ fun CelebrityItem(
                     contentScale = ContentScale.Crop,
                     contentDescription = null
                 )
-                VerticalGradiant(
+                VerticalGradient(
                     modifier = Modifier
                         .width(MovieItemWidth)
                         .align(Alignment.BottomStart),

--- a/shared/feature/src/commonMain/kotlin/com/moviearchive/feature/presentation/home/items/MovieItem.kt
+++ b/shared/feature/src/commonMain/kotlin/com/moviearchive/feature/presentation/home/items/MovieItem.kt
@@ -40,7 +40,7 @@ import com.moviearchive.ui.theme.SmallEvelation
 import com.moviearchive.ui.theme.SmallPadding
 import com.moviearchive.ui.theme.TinyPadding
 import com.moviearchive.ui.widget.AsyncImagePainter
-import com.moviearchive.ui.widget.VerticalGradiant
+import com.moviearchive.ui.widget.VerticalGradient
 
 @Composable
 fun MovieItem(
@@ -73,7 +73,7 @@ fun MovieItem(
                     contentScale = ContentScale.Crop,
                     contentDescription = null
                 )
-                VerticalGradiant(
+                VerticalGradient(
                     modifier = Modifier
                         .width(MovieItemWidth)
                         .align(Alignment.BottomStart),

--- a/shared/ui/src/androidMain/kotlin/com/moviearchive/ui/android/widget/Gradient.kt
+++ b/shared/ui/src/androidMain/kotlin/com/moviearchive/ui/android/widget/Gradient.kt
@@ -5,12 +5,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import com.moviearchive.ui.widget.VerticalGradiant
+import com.moviearchive.ui.widget.VerticalGradient
 
 @Preview
 @Composable
-private fun VerticalGradiantPreview() {
-    VerticalGradiant(
+private fun VerticalGradientPreview() {
+    VerticalGradient(
         modifier = Modifier,
         listColors = listOf(Color.White, Color.DarkGray, Color.Black)
     ) {

--- a/shared/ui/src/commonMain/kotlin/com/moviearchive/ui/widget/Gradient.kt
+++ b/shared/ui/src/commonMain/kotlin/com/moviearchive/ui/widget/Gradient.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 
 @Composable
-fun VerticalGradiant(
+fun VerticalGradient(
     modifier: Modifier,
     listColors: List<Color>,
     content: @Composable BoxScope.() -> Unit


### PR DESCRIPTION
## Summary
- rename VerticalGradiant composable to VerticalGradient
- update all references and preview names

## Testing
- `./gradlew build` *(fails: Could not determine the dependencies of task ':androidApp:packageDebug'. No matching toolchains found for requested specification: {languageVersion=17})*


------
https://chatgpt.com/codex/tasks/task_b_68a719f43a90832281e1f350113dc4e4