### PR TITLE
Handle nullable movie lookups

### DIFF
--- a/shared/data/src/commonMain/kotlin/com/moviearchive/data/repository/MovieRepositoryImpl.kt
+++ b/shared/data/src/commonMain/kotlin/com/moviearchive/data/repository/MovieRepositoryImpl.kt
@@ -41,8 +41,9 @@ class MovieRepositoryImpl(
     }
 
     override fun getFavorite(movieId: String): Flow<Result<MovieDataModel, Error>> =
-        dao.get(movieId).map {
-            Result.Success(it.toData())
+        dao.get(movieId).map { table ->
+            table?.let { Result.Success(it.toData()) }
+                ?: Result.Failure(Error(message = "Movie not found"))
         }.catch { throwable ->
             Result.Failure(Error(message = throwable.message ?: "", throwable = throwable))
         }

--- a/shared/data/src/commonMain/kotlin/com/moviearchive/data/source/db/dao/MovieDao.kt
+++ b/shared/data/src/commonMain/kotlin/com/moviearchive/data/source/db/dao/MovieDao.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
 interface MovieDao {
     fun getAll(): Flow<List<MovieTable>>
 
-    fun get(movieId: String): Flow<MovieTable>
+    fun get(movieId: String): Flow<MovieTable?>
 
     suspend fun insert(movie: MovieTable)
 

--- a/shared/data/src/commonMain/kotlin/com/moviearchive/data/source/db/dao/MovieDaoImpl.kt
+++ b/shared/data/src/commonMain/kotlin/com/moviearchive/data/source/db/dao/MovieDaoImpl.kt
@@ -2,7 +2,7 @@ package com.moviearchive.data.source.db.dao
 
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
-import app.cash.sqldelight.coroutines.mapToOne
+import app.cash.sqldelight.coroutines.mapToOneOrNull
 import com.moviearchive.DatabaseSource
 import com.moviearchive.data.source.db.util.Constant.THROW_QUERY_INSERT_MOVIE_EXCEPTION
 import com.moviearchive.sqldelight.MovieTable
@@ -21,10 +21,10 @@ class MovieDaoImpl constructor(
             .mapToList(Dispatchers.IO)
 
 
-    override fun get(movieId: String): Flow<MovieTable> =
+    override fun get(movieId: String): Flow<MovieTable?> =
         query.getMovie(movieId)
             .asFlow()
-            .mapToOne(Dispatchers.IO)
+            .mapToOneOrNull(Dispatchers.IO)
 
     override suspend fun insert(movie: MovieTable) {
         query.transaction {


### PR DESCRIPTION
## Summary
- Allow fetching a movie to emit `null` when not found.
- Use `mapToOneOrNull` for database mapping.
- Map missing movies to a `Result.Failure` in the repository.

## Testing
- ⚠️ `./gradlew build` (missing Java toolchain)
- ⚠️ `./gradlew :shared:data:compileKotlinIosX64` (dependency resolution failed)


------
https://chatgpt.com/codex/tasks/task_b_68a719f565208322b4aba86f3a03fafd